### PR TITLE
Fixes for Taiketsu (U + E) and Legacy of Goku II (E)

### DIFF
--- a/game_config.txt
+++ b/game_config.txt
@@ -1167,9 +1167,15 @@ game_code = ALFE
 vender_code = 70
 save_type = eeprom
 
-# Dragon Ball Z - Buu's Fury (U)
-game_name = DBZBUUSFURY
-game_code = BG3E
+# Dragon Ball Z - Taiketsu (U)
+game_name = DBZ TAIKETSU
+game_code = BDBE
+vender_code = 70
+save_type = eeprom
+
+# Dragon Ball Z - Taiketsu (E)
+game_name = DRAGON BALLZ
+game_code = BDBP
 vender_code = 70
 save_type = eeprom
 

--- a/game_config.txt
+++ b/game_config.txt
@@ -1167,6 +1167,12 @@ game_code = ALFE
 vender_code = 70
 save_type = eeprom
 
+# Dragon Ball Z - The Legacy of Goku II (E)
+game_name = DRAGONBALL Z
+game_code = ALFP
+vender_code = 70
+save_type = eeprom
+
 # Dragon Ball Z - Taiketsu (U)
 game_name = DBZ TAIKETSU
 game_code = BDBE


### PR DESCRIPTION
Apparently Buu's Fury (U) never triggered its AP to begin with on ReGBA. Affected games here have been confirmed to not work beforehand.
Maintains contents of the LoG2 (U) fix, as well as adding localized fix for LoG2 (E).