### PR TITLE
Add support for L2/R2 and PlayGo Menu button

### DIFF
--- a/source/opendingux/Makefile
+++ b/source/opendingux/Makefile
@@ -27,11 +27,16 @@ DEFS        := -DGCW_ZERO -DMIPS_XBURST                                       \
                -DSCREEN_WIDTH=320 -DSCREEN_HEIGHT=240                         \
                -DGIT_VERSION=$(shell git describe --always)
 
+ifdef PLAYGO
+	DEFS += -DPLAYGO
+	DEFS += -DUSE_MMAP
+else
 ifdef RG350
 	DEFS += -DRG350
 	DEFS += -DUSE_MMAP
 else
 	DEFS += -DLOAD_ALL_ROM
+endif
 endif
 HAS_MIPS32R2 := $(shell echo | $(CC) -dM -E - |grep _MIPS_ARCH_MIPS32R2)
 ifneq ($(HAS_MIPS32R2),)

--- a/source/opendingux/gui.c
+++ b/source/opendingux/gui.c
@@ -422,6 +422,8 @@ static char* OpenDinguxButtonText[OPENDINGUX_BUTTON_COUNT] = {
 	"Analog Up",
 	"Analog Left",
 	"Analog Right",
+	"L2",
+	"R2",
 };
 
 /*
@@ -589,6 +591,8 @@ static char OpenDinguxButtonSave[OPENDINGUX_BUTTON_COUNT] = {
 	'u',
 	'l',
 	'r', // (end)
+	'+',
+	'-',
 };
 
 static void LoadMappingFunction(struct MenuEntry* ActiveMenuEntry, char* Value)

--- a/source/opendingux/od-input.c
+++ b/source/opendingux/od-input.c
@@ -56,7 +56,9 @@ uint32_t OpenDinguxKeys[OPENDINGUX_BUTTON_COUNT] = {
 	0,
 	0,
 	0,
-#ifdef RG350
+#ifdef PLAYGO
+	SDLK_RCTRL       // PLAYGO: Menu face button
+#elif defined RG350
 	SDLK_HOME,       // RG359: Quick flick of Power
 #else
 	SDLK_3,          // GCW: Quick flick of Power

--- a/source/opendingux/od-input.c
+++ b/source/opendingux/od-input.c
@@ -57,9 +57,19 @@ uint32_t OpenDinguxKeys[OPENDINGUX_BUTTON_COUNT] = {
 	0,
 	0,
 #ifdef PLAYGO
-	SDLK_RCTRL       // PLAYGO: Menu face button
+	SDLK_RSHIFT,     // PLAYGO: L2
+	SDLK_RALT,       // PLAYGO: R2
 #elif defined RG350
-	SDLK_HOME,       // RG359: Quick flick of Power
+	SDLK_BACKSPACE,  // RG350: L2
+	SDLK_PAGEUP,     // RG350: R2
+#else
+	0,
+	0,
+#endif
+#ifdef PLAYGO
+	SDLK_RCTRL,      // PLAYGO: Menu face button
+#elif defined RG350
+	SDLK_HOME,       // RG350: Quick flick of Power
 #else
 	SDLK_3,          // GCW: Quick flick of Power
 #endif

--- a/source/opendingux/od-input.h
+++ b/source/opendingux/od-input.h
@@ -20,7 +20,7 @@
 #ifndef __OD_INPUT_H__
 #define __OD_INPUT_H__
 
-#define OPENDINGUX_BUTTON_COUNT 17
+#define OPENDINGUX_BUTTON_COUNT 19
 
 // These must be in the order defined in OpenDinguxKeys in od-input.c.
 enum OpenDingux_Buttons {
@@ -40,7 +40,9 @@ enum OpenDingux_Buttons {
 	OPENDINGUX_ANALOG_UP         = 0x02000,
 	OPENDINGUX_ANALOG_LEFT       = 0x04000,
 	OPENDINGUX_ANALOG_RIGHT      = 0x08000,
-	OPENDINGUX_BUTTON_MENU       = 0x10000,
+	OPENDINGUX_BUTTON_L2         = 0x10000,
+	OPENDINGUX_BUTTON_R2         = 0x20000,
+	OPENDINGUX_BUTTON_MENU       = 0x40000,
 };
 
 enum GUI_Action {


### PR DESCRIPTION
These two commits add support for L2/R2 buttons on the PlayGo and RG350, and for the Menu button on the PlayGo. I've taken the keysym values of the buttons for the RG350 from an input tester, but can't test it since I don't own an RG350 myself.

Everything seems to be working as expected on my PlayGo.

I didn't get any compiler warnings about the size of enum being only guaranteed to accommodate the `int` range, so I imagine MIPS `int` can fit all these buttons.